### PR TITLE
Fix: add_error_messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,6 @@ class ElasticLogger extends BaseLogger {
    * @param {object} bindings
    */
   getLogHandler(bindings) {
-    if (this.opts.excludeModules.includes(bindings.mod)) return null
-
     const level = bindings ? this.getLogLevel(bindings.mod) : null
     if (!level) return null
 
@@ -124,6 +122,8 @@ class ElasticLogger extends BaseLogger {
     return (type, args) => {
       const typeIdx = BaseLogger.LEVELS.indexOf(type)
       if (typeIdx > levelIdx) return
+      // allow only `error` and `fatal` from broker
+      if (this.opts.excludeModules.includes(bindings.mod) && !(bindings.mod === 'broker' && typeIdx <= 1)) return
 
       this.queue.push({
         ts: new Date(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@1xtr/moleculer-elasticsearch-logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@1xtr/moleculer-elasticsearch-logger",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@elastic/elasticsearch": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1xtr/moleculer-elasticsearch-logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Custom MoleculerJS logger for send logs to Elasticsearch directly",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
allow only `error` and `fatal` from broker

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>